### PR TITLE
fix hmatrix dependency

### DIFF
--- a/hvx.cabal
+++ b/hvx.cabal
@@ -1,5 +1,5 @@
 name               : hvx
-version            : 0.1.0.0
+version            : 0.2.0.0
 synopsis           : Solves convex optimization problems with subgradient methods.
 license-file       : LICENSE
 author             : Chris Copeland and Michael Haggblade
@@ -28,7 +28,7 @@ library
   -- closed type families need ghc>=7.8 which has base==4.7
   build-depends    : base < 5 && >= 4.7
                    , QuickCheck > 2.5
-                   , hmatrix
+                   , hmatrix > 0.15 && < 0.17
   hs-source-dirs   : src
   default-language : Haskell2010
   ghc-options      : -Wall
@@ -38,7 +38,7 @@ test-suite haskell-tests
   build-depends    : base < 5
                    , QuickCheck > 2.5
                    , hspec
-                   , hmatrix
+                   , hmatrix > 0.15 && < 0.17
   hs-source-dirs   : test, src
   main-is          : Spec.hs
   default-language : Haskell2010


### PR DESCRIPTION
hmatrix changed the API, so hvx cannot be installed with the current cabal file