### PR TITLE
Update to work with hmatrix 18.0.0.1 and ghc 8.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,18 +3,23 @@ HVX
 Disciplined Convex Programming and Symbolic Subdifferentiation in Haskell
 -------------------------------------------------------------------------
 
-This is the preferred version of HVX. An older version (compatible with GHC \>=7.6.3) is available at https://github.com/chrisnc/hvx-ghc-763.
+This is the preferred version of HVX. An older version (compatible with GHC \>=7.6.3) is available at https://github.com/chrisnc/hvx-ghc-763, as well as a version compatible with GHC \>7.8.2 in the git history of https://github.com/chrisnc/hvx.
 
-This version of HVX requires GHC \>=7.8.2 because it uses closed type families.  Until GHC 7.8.2 becomes more widely adopted by the various package managers this means that users will probably have to install GHC 7.8.2 themselves.
+This version of HVX requires GHC \>=8.2.1 because it uses a recent version of hmatrix.
 
 To install HVX:
- - Install GHC 7.8.2: http://www.haskell.org/ghc/download_ghc_7_8_2
- - Install the Cabal library and the cabal-install utility: http://www.haskell.org/cabal/download.html
+ - Install GHC 8.2.1 and cabal
  - Install your operating system's LAPACK and GSL packages.
- - `./install.sh` (no sudo needed).
+ - cabal sandbox init
+ - cabal configure --enable-tests
+ - cabal install
 
 See the examples directory for ways to use this package.
 
-Run the demo with:
+Run the demos with:
 
-    ghci examples/demo.hs
+    cabal run demo
+
+or:
+
+    cabal run subgrad

--- a/examples/demo.hs
+++ b/examples/demo.hs
@@ -1,5 +1,4 @@
 import Numeric.LinearAlgebra
-import Numeric.LinearAlgebra.Util (ones,zeros)
 import HVX
 
 n = 4
@@ -15,15 +14,14 @@ c = EConst $ (n><1) [1..]
 
 x = EVar "x"
 y = EVar "y"
-constNeg3 = EConst $ scale (-3.0) $ ones n 1
-constTwos = EConst $ scale 2.0 $ ones n 1
+constNeg3 = EConst $ scale (-3.0) $ konst 1.0 (n, 1)
+constTwos = EConst $ scale 2.0 $ konst 1.0 (n, 1)
 
 ans = subgradMinimize
   (norm 2 (a *~ x) +~ norm 2 (b *~ y) +~ norm 2 (c +~ x +~ neg y))
   [y <=~ constTwos, x <=~ constNeg3]
   (decNonSumStep 10.0) 5000
-  [("x",zeros n 1), ("y", zeros n 1)]
+  [("x", konst 0.0 (n, 1)), ("y", konst 0.0 (n, 1))]
 
 main :: IO ()
-main = do
-  putStrLn $ show ans
+main = print ans

--- a/examples/subgrad.hs
+++ b/examples/subgrad.hs
@@ -1,5 +1,5 @@
-import HVX
 import Numeric.LinearAlgebra
+import HVX
 
 -- declare a symbolic variable
 x = EVar "x"
@@ -9,3 +9,6 @@ vars = [("x", (4><1) [0,-3,1,2])]
 myexpr = hmax(habs(x))
 -- compute the subgradient
 mysubgrad = jacobianWrtVar myexpr vars "x"
+
+main :: IO ()
+main = print mysubgrad

--- a/hvx.cabal
+++ b/hvx.cabal
@@ -60,3 +60,23 @@ test-suite shell-tests
   main-is          : DcpTests.hs
   default-language : Haskell2010
   ghc-options      : -Wall
+
+executable demo
+  hs-source-dirs   : examples
+  main-is          : demo.hs
+  build-depends    : base < 5 && >= 4.7
+                   , QuickCheck > 2.5
+                   , hmatrix >= 0.18.0.1 && < 0.19
+                   , hvx
+  default-language : Haskell2010
+  ghc-options      : -Wall
+
+executable subgrad
+  hs-source-dirs   : examples
+  main-is          : subgrad.hs
+  build-depends    : base < 5 && >= 4.7
+                   , QuickCheck > 2.5
+                   , hmatrix >= 0.18.0.1 && < 0.19
+                   , hvx
+  default-language : Haskell2010
+  ghc-options      : -Wall

--- a/hvx.cabal
+++ b/hvx.cabal
@@ -1,12 +1,12 @@
 name               : hvx
-version            : 0.2.0.0
+version            : 0.3.0.0
 synopsis           : Solves convex optimization problems with subgradient methods.
 license-file       : LICENSE
 author             : Chris Copeland and Michael Haggblade
 category           : Math
 build-type         : Simple
 cabal-version      : >=1.20
-tested-with        : GHC == 7.8.2
+tested-with        : GHC == 8.2.1
 
 library
   exposed-modules  : HVX
@@ -28,7 +28,7 @@ library
   -- closed type families need ghc>=7.8 which has base==4.7
   build-depends    : base < 5 && >= 4.7
                    , QuickCheck > 2.5
-                   , hmatrix > 0.15 && < 0.17
+                   , hmatrix >= 0.18.0.1 && < 0.19
   hs-source-dirs   : src
   default-language : Haskell2010
   ghc-options      : -Wall
@@ -38,7 +38,7 @@ test-suite haskell-tests
   build-depends    : base < 5
                    , QuickCheck > 2.5
                    , hspec
-                   , hmatrix > 0.15 && < 0.17
+                   , hmatrix >= 0.18.0.1 && < 0.19
   hs-source-dirs   : test, src
   main-is          : Spec.hs
   default-language : Haskell2010

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,0 @@
-cabal clean
-cabal configure --enable-tests
-cabal build
-cabal install

--- a/src/HVX/Internal/Constraints.hs
+++ b/src/HVX/Internal/Constraints.hs
@@ -17,14 +17,14 @@ import HVX.Primitives
 import HVX.Internal.Primitives
 import HVX.Internal.DCP
 
-type Constraint = Expr Convex Nonmon
+type Constraint = Expr 'Convex 'Nonmon
 
 class CanConstrain (v :: Vex) where
     canConstrain :: e (v :: Vex) (m :: Mon) -> e v m
     canConstrain = id
 
-instance CanConstrain Convex
-instance CanConstrain Affine
+instance CanConstrain 'Convex
+instance CanConstrain 'Affine
 
 isConstraint :: Constraint -> Constraint
 isConstraint = id

--- a/src/HVX/Internal/DCP.hs
+++ b/src/HVX/Internal/DCP.hs
@@ -61,7 +61,7 @@ type family FlipMon m where
 -- determines the convexity of a function applied to an expression
 -- "newexpr = apply f expr"
 type family ApplyVex vf mf ve me where
-  ApplyVex vf      'Const   ve       me     = 'Affine
+  ApplyVex vf       'Const  ve       me     = 'Affine
   ApplyVex vf       mf      ve       'Const = 'Affine
   ApplyVex vf       mf      'Affine  me     = vf
   ApplyVex 'Affine  'Nondec ve       me     = ve

--- a/src/HVX/Internal/DCP.hs
+++ b/src/HVX/Internal/DCP.hs
@@ -21,77 +21,77 @@ class GetVex (v :: Vex) where
 
 -- | convexity
 data Vex = Affine | Convex | Concave | Nonvex
-instance GetVex Affine  where getVex _ = "Affine"
-instance GetVex Convex  where getVex _ = "Convex"
-instance GetVex Concave where getVex _ = "Concave"
-instance GetVex Nonvex  where getVex _ = "Nonvex"
+instance GetVex 'Affine  where getVex _ = "Affine"
+instance GetVex 'Convex  where getVex _ = "Convex"
+instance GetVex 'Concave where getVex _ = "Concave"
+instance GetVex 'Nonvex  where getVex _ = "Nonvex"
 
 class ValidVex (v :: Vex) where
     validVex :: e (v :: Vex) (m :: Mon) -> e v m
     validVex = id
 
-instance ValidVex Affine
-instance ValidVex Convex
-instance ValidVex Concave
+instance ValidVex 'Affine
+instance ValidVex 'Convex
+instance ValidVex 'Concave
 
 class GetMon (m :: Mon) where
   getMon :: e (v :: Vex) (m :: Mon) -> String
 
 -- | monotonicity
 data Mon = Const | Nondec | Noninc | Nonmon
-instance GetMon Const  where getMon _ = "Const"
-instance GetMon Nondec where getMon _ = "Nondec"
-instance GetMon Noninc where getMon _ = "Noninc"
-instance GetMon Nonmon where getMon _ = "Nonmon"
+instance GetMon 'Const  where getMon _ = "Const"
+instance GetMon 'Nondec where getMon _ = "Nondec"
+instance GetMon 'Noninc where getMon _ = "Noninc"
+instance GetMon 'Nonmon where getMon _ = "Nonmon"
 
 -- | invert convexities
 type family FlipVex v where
-  FlipVex Convex  = Concave
-  FlipVex Concave = Convex
-  FlipVex Affine  = Affine
-  FlipVex Nonvex  = Nonvex
+  FlipVex 'Convex  = 'Concave
+  FlipVex 'Concave = 'Convex
+  FlipVex 'Affine  = 'Affine
+  FlipVex 'Nonvex  = 'Nonvex
 
 -- | invert monotonicities
 type family FlipMon m where
-  FlipMon Const  = Const
-  FlipMon Nondec = Noninc
-  FlipMon Noninc = Nondec
-  FlipMon Nonmon = Nonmon
+  FlipMon 'Const  = 'Const
+  FlipMon 'Nondec = 'Noninc
+  FlipMon 'Noninc = 'Nondec
+  FlipMon 'Nonmon = 'Nonmon
 
 -- determines the convexity of a function applied to an expression
 -- "newexpr = apply f expr"
 type family ApplyVex vf mf ve me where
-  ApplyVex vf      Const  ve      me    = Affine
-  ApplyVex vf      mf     ve      Const = Affine
-  ApplyVex vf      mf     Affine  me    = vf
-  ApplyVex Affine  Nondec ve      me    = ve
-  ApplyVex Affine  Noninc ve      me    = FlipVex ve
-  ApplyVex v       Nondec v       me    = v
-  ApplyVex Convex  Noninc Concave me    = Convex
-  ApplyVex Concave Noninc Convex  me    = Concave
-  ApplyVex vf      mf     ve      me    = Nonvex
+  ApplyVex vf      'Const   ve       me     = 'Affine
+  ApplyVex vf       mf      ve       'Const = 'Affine
+  ApplyVex vf       mf      'Affine  me     = vf
+  ApplyVex 'Affine  'Nondec ve       me     = ve
+  ApplyVex 'Affine  'Noninc ve       me     = FlipVex ve
+  ApplyVex v        'Nondec v        me     = v
+  ApplyVex 'Convex  'Noninc 'Concave me     = 'Convex
+  ApplyVex 'Concave 'Noninc 'Convex  me     = 'Concave
+  ApplyVex vf       mf      ve       me     = 'Nonvex
 
 -- determines the monotonicity of a function applied to an expression
 -- "newexpr = apply f expr"
 type family ApplyMon mf me where
-  ApplyMon Const  me     = Const
-  ApplyMon mf     Const  = Const
-  ApplyMon Nondec me     = me
-  ApplyMon Noninc me     = FlipMon me
-  ApplyMon Nonmon me     = Nonmon
+  ApplyMon 'Const  me     = 'Const
+  ApplyMon mf      'Const = 'Const
+  ApplyMon 'Nondec me     = me
+  ApplyMon 'Noninc me     = FlipMon me
+  ApplyMon 'Nonmon me     = 'Nonmon
 
 -- determines the convexity of the sum of two expressions
 -- "newexpr = e1 +~ e2"
 type family AddVex v1 v2 where
-  AddVex Affine  v2      = v2
-  AddVex v1      Affine  = v1
+  AddVex 'Affine v2      = v2
+  AddVex v1      'Affine = v1
   AddVex v       v       = v
-  AddVex v1      v2      = Nonvex
+  AddVex v1      v2      = 'Nonvex
 
 -- determines the monotonicity of the sum of two expressions
 -- "newexpr = e1 +~ e2"
 type family AddMon m1 m2 where
-  AddMon m1     Const  = m1
-  AddMon Const  m2     = m2
+  AddMon m1     'Const = m1
+  AddMon 'Const m2     = m2
   AddMon m      m      = m
-  AddMon m1     m2     = Nonmon
+  AddMon m1     m2     = 'Nonmon

--- a/src/HVX/Internal/Matrix.hs
+++ b/src/HVX/Internal/Matrix.hs
@@ -13,8 +13,7 @@ module HVX.Internal.Matrix
   , zeroVec
   ) where
 
-import Numeric.LinearAlgebra hiding (i)
-import Numeric.LinearAlgebra.Util
+import Numeric.LinearAlgebra
 
 import HVX.Internal.Util
 
@@ -30,7 +29,7 @@ diagMat :: Mat -> Mat
 diagMat = diag . flatten
 
 ei :: Int -> Int -> Mat
-ei n i = buildMatrix n 1 (\(j, _) -> if i == j then 1 else 0)
+ei n i = assoc (n, 1) 0.0 [((i, 0), 1)]
 
 fpequalsMat :: Mat -> Mat -> Bool
 fpequalsMat a b
@@ -50,7 +49,7 @@ lpnorm p x = sumElements y ** (1/p)
         y = abs x ** pMat
 
 matrixPow :: Double -> Mat -> Mat
-matrixPow p = mapMatrix (** p)
+matrixPow p = cmap (** p)
 
 reduceMat :: ([Double] -> Double) -> Mat -> Mat
 reduceMat f = (1><1) . (:[]) . f . toList . flatten
@@ -59,7 +58,7 @@ scalarMat :: Double -> Mat
 scalarMat x = (1><1) [x]
 
 zeroMat :: Int -> Mat
-zeroMat n = zeros n n
+zeroMat n = konst 0.0 (n, n)
 
 zeroVec :: Int -> Mat
-zeroVec n = zeros n 1
+zeroVec n = konst 0.0 (n, 1)

--- a/src/HVX/Internal/Primitives.hs
+++ b/src/HVX/Internal/Primitives.hs
@@ -20,8 +20,8 @@ import HVX.Internal.DCP
 type Var = String
 
 data Expr vex mon where
-  EConst :: Mat -> Expr Affine Const
-  EVar   :: Var -> Expr Affine Nondec
+  EConst :: Mat -> Expr 'Affine 'Const
+  EVar   :: Var -> Expr 'Affine 'Nondec
   EFun   ::
 #ifndef DISABLE_EXPR_CXT
       ValidVex vex =>
@@ -43,23 +43,23 @@ getProperties :: (GetVex vex, GetMon mon) => Expr vex mon -> String
 getProperties expr = getVex expr ++ " " ++ getMon expr
 
 data Fun (vex :: Vex) (mon :: Mon) where
-  Mul                :: Mat -> Fun Affine Nonmon
-  Abs                :: Fun Convex Nonmon
-  Neg                :: Fun Affine Noninc
-  Log                :: Fun Concave Nondec
-  Exp                :: Fun Convex Nondec
-  LogSumExp          :: Fun Convex Nondec
-  Max                :: Fun Convex Nondec
-  Min                :: Fun Concave Nondec
-  Norm               :: Double -> Fun Convex Nonmon
-  Berhu              :: Double -> Fun Convex Nonmon
-  Huber              :: Double -> Fun Convex Nonmon
-  Quadform           :: Mat -> Fun Convex Nonmon
-  PowBaseP0          :: Fun Affine Const
-  PowBaseP01         :: Double -> Fun Concave Nondec
-  PowBaseP1          :: Fun Affine Nondec
-  PowBaseP1InfEven   :: Integer -> Fun Convex Nonmon
-  PowBaseP1InfNotInt :: Double -> Fun Convex Nondec
+  Mul                :: Mat -> Fun 'Affine 'Nonmon
+  Abs                :: Fun 'Convex 'Nonmon
+  Neg                :: Fun 'Affine 'Noninc
+  Log                :: Fun 'Concave 'Nondec
+  Exp                :: Fun 'Convex 'Nondec
+  LogSumExp          :: Fun 'Convex 'Nondec
+  Max                :: Fun 'Convex 'Nondec
+  Min                :: Fun 'Concave 'Nondec
+  Norm               :: Double -> Fun 'Convex 'Nonmon
+  Berhu              :: Double -> Fun 'Convex 'Nonmon
+  Huber              :: Double -> Fun 'Convex 'Nonmon
+  Quadform           :: Mat -> Fun 'Convex 'Nonmon
+  PowBaseP0          :: Fun 'Affine 'Const
+  PowBaseP01         :: Double -> Fun 'Concave 'Nondec
+  PowBaseP1          :: Fun 'Affine 'Nondec
+  PowBaseP1InfEven   :: Integer -> Fun 'Convex 'Nonmon
+  PowBaseP1InfNotInt :: Double -> Fun 'Convex 'Nondec
 
 instance Show (Fun vex mon) where
   show (Mul _) = "mul"

--- a/src/HVX/Internal/Primitives.hs
+++ b/src/HVX/Internal/Primitives.hs
@@ -12,8 +12,7 @@ module HVX.Internal.Primitives
   , getProperties
   ) where
 
-import Numeric.LinearAlgebra hiding (i)
-import Numeric.LinearAlgebra.Util hiding (norm)
+import Numeric.LinearAlgebra
 
 import HVX.Internal.Matrix
 import HVX.Internal.DCP
@@ -23,14 +22,14 @@ type Var = String
 data Expr vex mon where
   EConst :: Mat -> Expr Affine Const
   EVar   :: Var -> Expr Affine Nondec
-  EFun   :: 
+  EFun   ::
 #ifndef DISABLE_EXPR_CXT
-      ValidVex vex => 
+      ValidVex vex =>
 #endif
       Fun v1 m1 -> Expr v2 m2 -> Expr vex mon
   EAdd   ::
 #ifndef DISABLE_EXPR_CXT
-      ValidVex vex => 
+      ValidVex vex =>
 #endif
     Expr v1 m1 -> Expr v2 m2 -> Expr vex mon
 
@@ -97,8 +96,8 @@ getFun (Berhu m) x =
   cmap (\y -> if abs y <= m then abs y else (abs y ** 2 + m ** 2) / (2 * m)) x
 getFun (Huber m) x = 
   cmap (\y -> if abs y <= m then abs y ** 2 else 2 * m * abs y - m ** 2) x
-getFun (Quadform m) x = trans x <> m <> x
-getFun PowBaseP0 x = ones (rows x) (cols x)
+getFun (Quadform m) x = tr' x <> m <> x
+getFun PowBaseP0 x = konst 1.0 ((rows x), (cols x))
 getFun (PowBaseP01 p) x
   | allMat (0 <=) x = matrixPow p x
   | otherwise = error "Cannot raise negative number to power p with 0 < p < 1."
@@ -114,12 +113,12 @@ getJacobian Abs x = diagMat $ signum x
 getJacobian Neg x = (-1) * ident (rows x)
 getJacobian Log x = diagMat $ 1 / x
 getJacobian Exp x = diagMat $ exp x
-getJacobian LogSumExp x = trans $ scale (1 / sumElements (exp x)) $ exp x
-getJacobian Max x = trans $ ei (rows x) i
+getJacobian LogSumExp x = tr' $ scale (1 / sumElements (exp x)) $ exp x
+getJacobian Max x = tr' $ ei (rows x) i
   where (i, _) = maxIndex x
-getJacobian Min x = trans $ ei (rows x) i
+getJacobian Min x = tr' $ ei (rows x) i
   where (i, _) = minIndex x
-getJacobian (Norm p) x = trans $ if x == zeroVec n
+getJacobian (Norm p) x = tr' $ if x == zeroVec n
   then
     zeroVec n
   else
@@ -132,8 +131,8 @@ getJacobian (Berhu m) x = diagMat $
   cmap (\y -> if abs y <= m then signum y else y / m) x
 getJacobian (Huber m) x = diagMat $
   cmap (\y -> if abs y <= m then 2 * y else 2 * m * signum y) x
-getJacobian (Quadform m) x = scale 2 $ trans x <> m
-getJacobian PowBaseP0 x = zeros n n
+getJacobian (Quadform m) x = scale 2 $ tr' x <> m
+getJacobian PowBaseP0 x = konst 0.0 (n, n)
   where n = rows x
 getJacobian (PowBaseP01 p) x = scale p $ diagMat $ matrixPow (p - 1) x
 getJacobian PowBaseP1 x = ident n

--- a/src/HVX/Internal/Primitives.hs
+++ b/src/HVX/Internal/Primitives.hs
@@ -96,7 +96,7 @@ getFun (Berhu m) x =
   cmap (\y -> if abs y <= m then abs y else (abs y ** 2 + m ** 2) / (2 * m)) x
 getFun (Huber m) x = 
   cmap (\y -> if abs y <= m then abs y ** 2 else 2 * m * abs y - m ** 2) x
-getFun (Quadform m) x = tr' x <> m <> x
+getFun (Quadform m) x = tr x <> m <> x
 getFun PowBaseP0 x = konst 1.0 ((rows x), (cols x))
 getFun (PowBaseP01 p) x
   | allMat (0 <=) x = matrixPow p x
@@ -113,12 +113,12 @@ getJacobian Abs x = diagMat $ signum x
 getJacobian Neg x = (-1) * ident (rows x)
 getJacobian Log x = diagMat $ 1 / x
 getJacobian Exp x = diagMat $ exp x
-getJacobian LogSumExp x = tr' $ scale (1 / sumElements (exp x)) $ exp x
-getJacobian Max x = tr' $ ei (rows x) i
+getJacobian LogSumExp x = tr $ scale (1 / sumElements (exp x)) $ exp x
+getJacobian Max x = tr $ ei (rows x) i
   where (i, _) = maxIndex x
-getJacobian Min x = tr' $ ei (rows x) i
+getJacobian Min x = tr $ ei (rows x) i
   where (i, _) = minIndex x
-getJacobian (Norm p) x = tr' $ if x == zeroVec n
+getJacobian (Norm p) x = tr $ if x == zeroVec n
   then
     zeroVec n
   else
@@ -131,7 +131,7 @@ getJacobian (Berhu m) x = diagMat $
   cmap (\y -> if abs y <= m then signum y else y / m) x
 getJacobian (Huber m) x = diagMat $
   cmap (\y -> if abs y <= m then 2 * y else 2 * m * signum y) x
-getJacobian (Quadform m) x = scale 2 $ tr' x <> m
+getJacobian (Quadform m) x = scale 2 $ tr x <> m
 getJacobian PowBaseP0 x = konst 0.0 (n, n)
   where n = rows x
 getJacobian (PowBaseP01 p) x = scale p $ diagMat $ matrixPow (p - 1) x

--- a/src/HVX/Internal/Solvers.hs
+++ b/src/HVX/Internal/Solvers.hs
@@ -63,7 +63,7 @@ subgradLoop :: Int -> Expr vex mon -> [Constraint] -> (Int -> Double) -> Int -> 
   -> (Vars, Double)
 subgradLoop itr objective constraints stepFun maxItr vars =
   if itr >= maxItr || vars == varsNext
-    then (vars, evaluate objective vars @@> (0,0))
+    then (vars, evaluate objective vars `atIndex` (0,0))
     else subgradLoop (itr + 1) objective constraints stepFun maxItr varsNext
       where varsNext = map (updateWithSubgrad objective constraints (stepFun itr) vars) vars
 
@@ -72,7 +72,7 @@ updateWithSubgrad objective constraints stepSize vars (varname, val) =
   if any isNaN (toList $ flatten g)
     then (varname, val)
     else (varname, val - scale stepSize g)
-      where g = fromMaybe (trans $ jacobianWrtVar objective vars varname) $
+      where g = fromMaybe (tr' $ jacobianWrtVar objective vars varname) $
                           getConstraintSubgrad constraints vars varname
 
 type Soid = (Var, Mat, Mat)
@@ -111,7 +111,7 @@ ellipsoidLoop objective constraints tol soids lbound ubound =
       where updates = map (updateEllipsoid objective constraints centers) soids
             nsoids = map fst updates
             sqrtgpgsum = sqrt . sum . map snd $ updates
-            objval = evaluate objective centers @@> (0,0)
+            objval = evaluate objective centers `atIndex` (0,0)
             nlbound = max lbound $ objval - sqrtgpgsum
             nubound = min ubound objval
             centers = map (\(name, val, _) -> (name, val)) soids
@@ -121,15 +121,15 @@ updateEllipsoid objective constraints vars soid =
   if gpg == 0.0
     then (soid, objgpg)
     else (nsoid, objgpg)
-      where objg = trans $ jacobianWrtVar objective vars varname
+      where objg = tr' $ jacobianWrtVar objective vars varname
             g = fromMaybe objg $ getConstraintSubgrad constraints vars varname
             n = fromIntegral $ rows val
-            gpg = (@@> (0,0)) $ trans g <> p <> g
-            objgpg = (@@> (0,0)) $ trans objg <> p <> objg
+            gpg = (`atIndex` (0,0)) $ tr' g <> p <> g
+            objgpg = (`atIndex` (0,0)) $ tr' objg <> p <> objg
             gtilde = scale (1 / sqrt gpg) g
             nval = val - scale (1 / (n + 1)) (p <> gtilde)
             np = scale (n**2 / (n**2 - 1)) $
-              p - scale (2/(n+1)) (p <> (gtilde <> trans gtilde) <> p)
+              p - scale (2/(n+1)) (p <> (gtilde <> tr' gtilde) <> p)
             (varname, val, p) = soid
             nsoid = (varname, nval, np)
 
@@ -140,6 +140,6 @@ getConstraintSubgrad constraints vars var =
   if null constraints || maxVal < 0.0
     then Nothing
     else Just cg
-      where cg = trans $ jacobianWrtVar maxConstraint vars var
+      where cg = tr' $ jacobianWrtVar maxConstraint vars var
             (maxConstraint, maxVal) = maximumBy (comparing snd) constraintViolations
-            constraintViolations = map (\c -> (c, evaluate c vars @@> (0,0))) constraints
+            constraintViolations = map (\c -> (c, evaluate c vars `atIndex` (0,0))) constraints

--- a/src/HVX/Internal/Solvers.hs
+++ b/src/HVX/Internal/Solvers.hs
@@ -26,8 +26,8 @@ import HVX.Internal.SymbolicSubgrad
 import HVX.Internal.Util
 
 class ValidVex vex => CanMinimize (vex :: Vex)
-instance CanMinimize Affine
-instance CanMinimize Convex
+instance CanMinimize 'Affine
+instance CanMinimize 'Convex
 
 -- | Constant step size.
 constStep :: Double -> Int -> Double
@@ -48,7 +48,7 @@ subgradMinimize :: CanMinimize vex =>
 subgradMinimize = subgradLoop 1
 
 -- | Use subgradient method to solve a maximization problem.
-subgradMaximize :: CanMinimize (ApplyVex Affine Noninc vex mon) =>
+subgradMaximize :: CanMinimize (ApplyVex 'Affine 'Noninc vex mon) =>
      Expr vex mon     -- ^ Objective to maximize.
   -> [Constraint]     -- ^ Constraints on maximization problem.
   -> (Int -> Double)  -- ^ Stepsize function.
@@ -90,7 +90,7 @@ ellipsoidMinimize objective constraints varsizes tol radius =
     where soids = map (\(name,n) -> (name, zeroVec n, scale radius $ ident n)) varsizes
 
 -- | Use ellipsoid method to solve a maximization problem.
-ellipsoidMaximize :: CanMinimize (ApplyVex Affine Noninc vex mon) =>
+ellipsoidMaximize :: CanMinimize (ApplyVex 'Affine 'Noninc vex mon) =>
      Expr vex mon            -- ^ Objective to maximize.
   -> [Constraint]            -- ^ Constraints on maximization problem.
   -> [(Var,Int)]             -- ^ Variable names and their sizes.

--- a/src/HVX/Internal/Solvers.hs
+++ b/src/HVX/Internal/Solvers.hs
@@ -72,7 +72,7 @@ updateWithSubgrad objective constraints stepSize vars (varname, val) =
   if any isNaN (toList $ flatten g)
     then (varname, val)
     else (varname, val - scale stepSize g)
-      where g = fromMaybe (tr' $ jacobianWrtVar objective vars varname) $
+      where g = fromMaybe (tr $ jacobianWrtVar objective vars varname) $
                           getConstraintSubgrad constraints vars varname
 
 type Soid = (Var, Mat, Mat)
@@ -121,15 +121,15 @@ updateEllipsoid objective constraints vars soid =
   if gpg == 0.0
     then (soid, objgpg)
     else (nsoid, objgpg)
-      where objg = tr' $ jacobianWrtVar objective vars varname
+      where objg = tr $ jacobianWrtVar objective vars varname
             g = fromMaybe objg $ getConstraintSubgrad constraints vars varname
             n = fromIntegral $ rows val
-            gpg = (`atIndex` (0,0)) $ tr' g <> p <> g
-            objgpg = (`atIndex` (0,0)) $ tr' objg <> p <> objg
+            gpg = (`atIndex` (0,0)) $ tr g <> p <> g
+            objgpg = (`atIndex` (0,0)) $ tr objg <> p <> objg
             gtilde = scale (1 / sqrt gpg) g
             nval = val - scale (1 / (n + 1)) (p <> gtilde)
             np = scale (n**2 / (n**2 - 1)) $
-              p - scale (2/(n+1)) (p <> (gtilde <> tr' gtilde) <> p)
+              p - scale (2/(n+1)) (p <> (gtilde <> tr gtilde) <> p)
             (varname, val, p) = soid
             nsoid = (varname, nval, np)
 
@@ -140,6 +140,6 @@ getConstraintSubgrad constraints vars var =
   if null constraints || maxVal < 0.0
     then Nothing
     else Just cg
-      where cg = tr' $ jacobianWrtVar maxConstraint vars var
+      where cg = tr $ jacobianWrtVar maxConstraint vars var
             (maxConstraint, maxVal) = maximumBy (comparing snd) constraintViolations
             constraintViolations = map (\c -> (c, evaluate c vars `atIndex` (0,0))) constraints

--- a/src/HVX/Internal/SymbolicSubgrad.hs
+++ b/src/HVX/Internal/SymbolicSubgrad.hs
@@ -2,8 +2,7 @@
 
 module HVX.Internal.SymbolicSubgrad where
 
-import Numeric.LinearAlgebra hiding (i)
-import Numeric.LinearAlgebra.Util
+import Numeric.LinearAlgebra
 
 import HVX.Internal.Matrix
 import HVX.Internal.Primitives
@@ -23,11 +22,11 @@ jacobianWrtVar :: Expr vex mon  -- ^ Expression whose jacobian to take.
   -> Var                        -- ^ Variable to take jacobian with respect to.
   -> Mat                        -- ^ The jacobian.
 jacobianWrtVar (EConst c) vars wrtVar
-    | Just wrtVal <- lookup wrtVar vars = zeros (rows c) (rows wrtVal)
+    | Just wrtVal <- lookup wrtVar vars = konst 0.0 ((rows c), (rows wrtVal))
     | otherwise = error $ "Variable " ++ show wrtVar ++ " not set."
 jacobianWrtVar (EVar var) vars wrtVar
     | var == wrtVar, Just val <- lookup var vars = ident $ rows val
-    | Just val <- lookup var vars, Just wrtVal <- lookup wrtVar vars = zeros (rows val) (rows wrtVal)
+    | Just val <- lookup var vars, Just wrtVal <- lookup wrtVar vars = konst 0.0 ((rows val), (rows wrtVal))
     | otherwise = error $ "Variable " ++ show var ++ " or " ++ show wrtVar ++ " not set."
 -- Chain rule: ddx f(e) = dde f * ddx e
 jacobianWrtVar (EFun f e) vars var = dde_f <> ddx_e

--- a/src/HVX/Primitives.hs
+++ b/src/HVX/Primitives.hs
@@ -28,8 +28,8 @@ module HVX.Primitives
   , powBaseP1InfNotInt
   ) where
 
-import Numeric.LinearAlgebra hiding (i)
-import Numeric.LinearAlgebra.LAPACK
+import Numeric.LinearAlgebra
+import Numeric.LinearAlgebra.HMatrix (eigSH')
 
 import HVX.Internal.DCP
 import HVX.Internal.Matrix
@@ -112,8 +112,8 @@ quadform :: (ApplyVex Convex Nonmon Affine m1 ~ v2, ValidVex v2)
   => Expr Affine Const -> Expr Affine m1 -> Expr v2 (ApplyMon Nonmon m1)
 quadform (EConst a) e
   | rows a == cols a
-    && fpequalsMat a (trans a)
-    && 0 <= maxElement (eigOnlyS a) = apply (Quadform a) e
+    && fpequalsMat a (tr a)
+    && 0 <= (maxElement.fst.eigSH' $ a) = apply (Quadform a) e -- we have checked that the matrix being passed in is Hermitian, so it's safe to use eigSH'.
   | otherwise = error "Matrices in quadratic forms must be positive semidefinite."
 quadform _ _ = error "The matrix sandwitched by the quadratic form must be constant."
 

--- a/src/HVX/Primitives.hs
+++ b/src/HVX/Primitives.hs
@@ -50,66 +50,66 @@ infixl 6 +~
 (+~) = hadd
 
 -- Constructors that enforce DCP constraints.
-hmul :: (ApplyVex Affine Nonmon v1 m1 ~ v2, ValidVex v2)
-  => Expr Affine Const -> Expr v1 m1 -> Expr v2 (ApplyMon Nonmon m1)
+hmul :: (ApplyVex 'Affine 'Nonmon v1 m1 ~ v2, ValidVex v2)
+  => Expr 'Affine 'Const -> Expr v1 m1 -> Expr v2 (ApplyMon 'Nonmon m1)
 hmul (EConst a) e = apply (Mul a) e
 hmul _ _ = error "the left argument of a multiply must be a constant"
 
 infixl 7 *~
-(*~) :: (ApplyVex Affine Nonmon v1 m1 ~ v2, ValidVex v2)
-  => Expr Affine Const -> Expr v1 m1 -> Expr v2 (ApplyMon Nonmon m1)
+(*~) :: (ApplyVex 'Affine 'Nonmon v1 m1 ~ v2, ValidVex v2)
+  => Expr 'Affine 'Const -> Expr v1 m1 -> Expr v2 (ApplyMon 'Nonmon m1)
 (*~) (EConst a) e = apply (Mul a) e
 (*~) _ _ = error "the left argument of a multiply must be a constant"
 
-habs :: (ApplyVex Convex Nonmon v1 m1 ~ v2, ValidVex v2)
-  => Expr v1 m1 -> Expr v2 (ApplyMon Nonmon m1)
+habs :: (ApplyVex 'Convex 'Nonmon v1 m1 ~ v2, ValidVex v2)
+  => Expr v1 m1 -> Expr v2 (ApplyMon 'Nonmon m1)
 habs = apply Abs
 
-neg :: (ApplyVex Affine Noninc v1 m1 ~ v2, ValidVex v2)
-  => Expr v1 m1 -> Expr v2 (ApplyMon Noninc m1)
+neg :: (ApplyVex 'Affine 'Noninc v1 m1 ~ v2, ValidVex v2)
+  => Expr v1 m1 -> Expr v2 (ApplyMon 'Noninc m1)
 neg = apply Neg
 
-hlog :: (ApplyVex Concave Nondec v1 m1 ~ v2, ValidVex v2)
-  => Expr v1 m1 -> Expr v2 (ApplyMon Nondec m1)
+hlog :: (ApplyVex 'Concave 'Nondec v1 m1 ~ v2, ValidVex v2)
+  => Expr v1 m1 -> Expr v2 (ApplyMon 'Nondec m1)
 hlog = apply Log
 
-hexp :: (ApplyVex Convex Nondec v1 m1 ~ v2, ValidVex v2)
-  => Expr v1 m1 -> Expr v2 (ApplyMon Nondec m1)
+hexp :: (ApplyVex 'Convex 'Nondec v1 m1 ~ v2, ValidVex v2)
+  => Expr v1 m1 -> Expr v2 (ApplyMon 'Nondec m1)
 hexp e = apply Exp e
 
-logsumexp :: (ApplyVex Convex Nondec v1 m1 ~ v2, ValidVex v2)
-  => Expr v1 m1 -> Expr v2 (ApplyMon Nondec m1)
+logsumexp :: (ApplyVex 'Convex 'Nondec v1 m1 ~ v2, ValidVex v2)
+  => Expr v1 m1 -> Expr v2 (ApplyMon 'Nondec m1)
 logsumexp = apply LogSumExp
 
-hmax :: (ApplyVex Convex Nondec v1 m1 ~ v2, ValidVex v2)
-  => Expr v1 m1 -> Expr v2 (ApplyMon Nondec m1)
+hmax :: (ApplyVex 'Convex 'Nondec v1 m1 ~ v2, ValidVex v2)
+  => Expr v1 m1 -> Expr v2 (ApplyMon 'Nondec m1)
 hmax = apply Max
 
-hmin :: (ApplyVex Concave Nondec v1 m1 ~ v2, ValidVex v2)
-  => Expr v1 m1 -> Expr v2 (ApplyMon Nondec m1)
+hmin :: (ApplyVex 'Concave 'Nondec v1 m1 ~ v2, ValidVex v2)
+  => Expr v1 m1 -> Expr v2 (ApplyMon 'Nondec m1)
 hmin = apply Min
 
-norm :: (ApplyVex Convex Nonmon v1 m1 ~ v2, ValidVex v2)
-  => Double -> Expr v1 m1 -> Expr v2 (ApplyMon Nonmon m1)
+norm :: (ApplyVex 'Convex 'Nonmon v1 m1 ~ v2, ValidVex v2)
+  => Double -> Expr v1 m1 -> Expr v2 (ApplyMon 'Nonmon m1)
 norm p
   | p == infinity = error "Internal: Infinity norm should become max . abs."
   | 1 <= p = apply (Norm p)
   | otherwise = error "Internal: Norm only supports p >= 1."
 
-berhu :: (ApplyVex Convex Nonmon v1 m1 ~ v2, ValidVex v2)
-  => Double -> Expr v1 m1 -> Expr v2 (ApplyMon Nonmon m1)
+berhu :: (ApplyVex 'Convex 'Nonmon v1 m1 ~ v2, ValidVex v2)
+  => Double -> Expr v1 m1 -> Expr v2 (ApplyMon 'Nonmon m1)
 berhu m
   | 0 < m = apply (Berhu m)
   | otherwise = error "Internal: Berhu only supports m >= 0."
 
-huber :: (ApplyVex Convex Nonmon v1 m1 ~ v2, ValidVex v2)
-  => Double -> Expr v1 m1 -> Expr v2 (ApplyMon Nonmon m1)
+huber :: (ApplyVex 'Convex 'Nonmon v1 m1 ~ v2, ValidVex v2)
+  => Double -> Expr v1 m1 -> Expr v2 (ApplyMon 'Nonmon m1)
 huber m
   | 0 < m = apply (Huber m)
   | otherwise = error "Internal: Huber only supports m >= 0."
 
-quadform :: (ApplyVex Convex Nonmon Affine m1 ~ v2, ValidVex v2)
-  => Expr Affine Const -> Expr Affine m1 -> Expr v2 (ApplyMon Nonmon m1)
+quadform :: (ApplyVex 'Convex 'Nonmon 'Affine m1 ~ v2, ValidVex v2)
+  => Expr 'Affine 'Const -> Expr 'Affine m1 -> Expr v2 (ApplyMon 'Nonmon m1)
 quadform (EConst a) e
   | rows a == cols a
     && fpequalsMat a (tr a)
@@ -117,33 +117,33 @@ quadform (EConst a) e
   | otherwise = error "Matrices in quadratic forms must be positive semidefinite."
 quadform _ _ = error "The matrix sandwitched by the quadratic form must be constant."
 
-powBaseP0 :: (ApplyVex Affine Const v1 m1 ~ v2, ValidVex v2)
-  => Double -> Expr v1 m1 -> Expr v2 (ApplyMon Const m1)
+powBaseP0 :: (ApplyVex 'Affine 'Const v1 m1 ~ v2, ValidVex v2)
+  => Double -> Expr v1 m1 -> Expr v2 (ApplyMon 'Const m1)
 powBaseP0 p
   | p `fpequals` 0 = apply PowBaseP0
   | otherwise = error "Internal: PowBaseP0 only supports p == 0."
 
-powBaseP01 :: (ApplyVex Concave Nondec v1 m1 ~ v2, ValidVex v2)
-  => Double -> Expr v1 m1 -> Expr v2 (ApplyMon Nondec m1)
+powBaseP01 :: (ApplyVex 'Concave 'Nondec v1 m1 ~ v2, ValidVex v2)
+  => Double -> Expr v1 m1 -> Expr v2 (ApplyMon 'Nondec m1)
 powBaseP01 p
   | 0 < p && p < 1 = apply (PowBaseP01 p)
   | otherwise = error "Internal: PowBaseP01 only supports 0 < p < 1."
 
-powBaseP1 :: (ApplyVex Affine Nondec v1 m1 ~ v2, ValidVex v2)
-  => Double -> Expr v1 m1 -> Expr v2 (ApplyMon Nondec m1)
+powBaseP1 :: (ApplyVex 'Affine 'Nondec v1 m1 ~ v2, ValidVex v2)
+  => Double -> Expr v1 m1 -> Expr v2 (ApplyMon 'Nondec m1)
 powBaseP1 p
   | p `fpequals` 1 = apply PowBaseP1
   | otherwise = error "Internal: PowBaseP1 only supports p == 1."
 
-powBaseP1InfEven :: (ApplyVex Convex Nonmon v1 m1 ~ v2, ValidVex v2)
-  => Double -> Expr v1 m1 -> Expr v2 (ApplyMon Nonmon m1)
+powBaseP1InfEven :: (ApplyVex 'Convex 'Nonmon v1 m1 ~ v2, ValidVex v2)
+  => Double -> Expr v1 m1 -> Expr v2 (ApplyMon 'Nonmon m1)
 powBaseP1InfEven p
   | 1 < p && isInteger p && even intP = apply (PowBaseP1InfEven intP)
   | otherwise = error "Internal: PowBaseP1InfEven only supports even p > 1."
   where intP = round p :: Integer
 
-powBaseP1InfNotInt :: (ApplyVex Convex Nondec v1 m1 ~ v2, ValidVex v2)
-  => Double -> Expr v1 m1 -> Expr v2 (ApplyMon Nondec m1)
+powBaseP1InfNotInt :: (ApplyVex 'Convex 'Nondec v1 m1 ~ v2, ValidVex v2)
+  => Double -> Expr v1 m1 -> Expr v2 (ApplyMon 'Nondec m1)
 powBaseP1InfNotInt p
   | 1 < p && not (isInteger p) = apply (PowBaseP1InfNotInt p)
   | otherwise = error "Internal: PowBaseP1InfNotInt only supports non integral p > 1."

--- a/test/DcpTests/NoConcaveLeq.hs
+++ b/test/DcpTests/NoConcaveLeq.hs
@@ -1,13 +1,12 @@
 module HVX.DcpTests.NoConcaveLeq where
 
 import Numeric.LinearAlgebra
-import Numeric.LinearAlgebra.Util
 
 import HVX
 
 main :: IO ()
 main = do
-  let zero = EConst $ zeros 2 1
+  let zero = EConst $ konst 0.0 (2, 1)
       x = EVar "x"
       e = hexp $ x
       _ = zero <=~ e

--- a/test/DcpTests/NoConvexGeq.hs
+++ b/test/DcpTests/NoConvexGeq.hs
@@ -1,13 +1,12 @@
 module HVX.DcpTests.NoConvexGeq where
 
 import Numeric.LinearAlgebra
-import Numeric.LinearAlgebra.Util
 
 import HVX
 
 main :: IO ()
 main = do
-  let zero = EConst $ zeros 2 1
+  let zero = EConst $ konst 0.0 (2, 1)
       x = EVar "x"
       e = hexp $ x
       _ = e >=~ zero

--- a/test/DcpTests/OkConstraints.hs
+++ b/test/DcpTests/OkConstraints.hs
@@ -1,13 +1,12 @@
 module HVX.DcpTests.OkXAffine where
 
 import Numeric.LinearAlgebra
-import Numeric.LinearAlgebra.Util
 
 import HVX
 
 main :: IO ()
 main = do
-  let zero = EConst $ zeros 2 1
+  let zero = EConst $ konst 0.0 (2, 1)
       x = EVar "x"
       e = hexp $ x
       _ = zero >=~ e

--- a/test/HVX/BlackBoxTests/HuberTestSpec.hs
+++ b/test/HVX/BlackBoxTests/HuberTestSpec.hs
@@ -4,7 +4,6 @@ module HVX.BlackBoxTests.HuberTestSpec where
 
 import Test.Hspec
 import Numeric.LinearAlgebra
-import Numeric.LinearAlgebra.Util (zeros)
 
 import HVX
 import HVX.Internal.TestUtil
@@ -28,13 +27,13 @@ d = EConst $ (n><1)
 
 x = EVar "x"
 y = EVar "y"
-constZeroVector = EConst $ zeros n 1
+constZeroVector = EConst $ konst 0.0 (n, 1)
 
 subgradAns = subgradMinimize
   (hmax $ huber 3 (a *~ x +~ b) +~ berhu 1 (c *~ y +~ d))
   [x +~ y <=~ constZeroVector]
   (decNonSumStep 1.0) 100000
-  [("x", zeros n 1), ("y", zeros n 1)]
+  [("x", konst 0.0 (n, 1)), ("y", konst 0.0 (n, 1))]
 
 ellipsoidAns = ellipsoidMinimize
   (hmax $ huber 3 (a *~ x +~ b) +~ berhu 1 (c *~ y +~ d))

--- a/test/HVX/BlackBoxTests/ManyvarTestSpec.hs
+++ b/test/HVX/BlackBoxTests/ManyvarTestSpec.hs
@@ -4,10 +4,8 @@ module HVX.BlackBoxTests.ManyvarTestSpec where
 
 import Test.Hspec
 import Numeric.LinearAlgebra
-import Numeric.LinearAlgebra.Util (ones, zeros)
 
 import HVX
-import HVX.Internal.TestUtil
 
 -- Problem definition.
 nx = 2
@@ -31,9 +29,9 @@ d = EConst $ (3><1)
 x = EVar "x"
 y = EVar "y"
 z = EVar "z"
-const10nx = EConst $ scale 10 $ ones nx 1
-const10ny = EConst $ scale 10 $ ones ny 1
-const01nz = EConst $ scale 0.1 $ ones nz 1
+const10nx = EConst $ scale 10 $ konst 1.0 (nx, 1)
+const10ny = EConst $ scale 10 $ konst 1.0 (ny, 1)
+const01nz = EConst $ scale 0.1 $ konst 1.0 (nz, 1)
 
 subgradAns = subgradMaximize
   ( neg (norm 2 (a *~ x +~ b *~ y +~ c *~ z +~ d))
@@ -43,7 +41,7 @@ subgradAns = subgradMaximize
     , powBaseP01 0.25 x >=~ const10nx
     , powBaseP1InfNotInt 1.75 y <=~ const10ny ]
   (decNonSumStep 100.0) 10
-  [("x", zeros nx 1), ("y", zeros ny 1), ("z", zeros nz 1)]
+  [("x", konst 0.0 (nx, 1)), ("y", konst 0.0 (ny, 1)), ("z", konst 0.0 (nz, 1))]
 
 ellipsoidAns = ellipsoidMaximize
   ( neg (norm 2 (a *~ x +~ b *~ y +~ c *~ z +~ d))

--- a/test/HVX/SymbolicSubgradSpec.hs
+++ b/test/HVX/SymbolicSubgradSpec.hs
@@ -62,7 +62,7 @@ evaluateSpec = describe "evaluate" $ do
     it "lpnorm(x, 2)^2 = x^T * x" $ property $
       forAll vectors $
         \x -> fpequalsMat
-          (tr' x <> x)
+          (tr x <> x)
           (evaluate
             (EFun (PowBaseP1InfEven 2) (norm 2 (EVar "x")))
             [("x", x)])
@@ -74,7 +74,7 @@ evaluateSpec = describe "evaluate" $ do
           (evaluate
             (EFun (Quadform (ident $ rows x)) (EVar "x"))
             [("x", x)])
-          (tr' x <> x)
+          (tr x <> x)
 
   describe "pow (base variable)" $ do
     it "(x^a)^(1/a) = x (a non integral, a > 1)" $ property $
@@ -134,7 +134,7 @@ jacobianWrtVarSpec = describe "jacobianWrtVar" $ do
             (EAdd (EFun Max (EVar "x")) (EFun Min (EFun Neg (EVar "x"))))
             [("x", x)]
             "x")
-          (tr' $ zeroVec $ rows x)
+          (tr $ zeroVec $ rows x)
 
   describe "lpnorm" $ do
     it "jacobian lpnorm(x, 1) = jacobian sum(abs(x))" $ property $
@@ -151,7 +151,7 @@ jacobianWrtVarSpec = describe "jacobianWrtVar" $ do
     it "jacobian lpnorm(0, 2) = 0" $ property $
       \(Positive n) -> fpequalsMat
         (jacobianWrtVar (norm 2 (EVar "x")) [("x", zeroVec n)] "x")
-        (tr' $ zeroVec n)
+        (tr $ zeroVec n)
 
   describe "quadform" $
     it "jacobian quadform(I, x) = jacobian lpnorm(x, 2)^2" $ property $


### PR DESCRIPTION
Would you mind looking this over? I know you don't maintain this any more but I'm specifically not sure I always used the right transpose function. I used tr' everywhere you used trans, I think that should be right. There's only one place I used tr instead of tr', and that's when we're checking that a matrix is Hermitian to use eigSH'.

Do you think the tests would catch out issues like these? Are they reasonably complete? I refactored them but I have not looked at what they actually do. Thanks.