### PR TITLE
Fix memory leak in subgradLoop and ellipsoidLoop

### DIFF
--- a/hvx.cabal
+++ b/hvx.cabal
@@ -29,6 +29,7 @@ library
   build-depends    : base < 5 && >= 4.7
                    , QuickCheck > 2.5
                    , hmatrix >= 0.18.0.1 && < 0.19
+                   , deepseq >= 1.4.3.0 && < 1.5
   hs-source-dirs   : src
   default-language : Haskell2010
   ghc-options      : -Wall
@@ -39,6 +40,7 @@ test-suite haskell-tests
                    , QuickCheck > 2.5
                    , hspec
                    , hmatrix >= 0.18.0.1 && < 0.19
+                   , deepseq >= 1.4.3.0 && < 1.5
   hs-source-dirs   : test, src
   main-is          : Spec.hs
   default-language : Haskell2010
@@ -56,6 +58,7 @@ test-suite shell-tests
                    , directory
                    , process
                    , filepath
+                   , deepseq >= 1.4.3.0 && < 1.5
   hs-source-dirs   : test
   main-is          : DcpTests.hs
   default-language : Haskell2010
@@ -68,6 +71,7 @@ executable demo
                    , QuickCheck > 2.5
                    , hmatrix >= 0.18.0.1 && < 0.19
                    , hvx
+                   , deepseq >= 1.4.3.0 && < 1.5
   default-language : Haskell2010
   ghc-options      : -Wall
 
@@ -78,5 +82,6 @@ executable subgrad
                    , QuickCheck > 2.5
                    , hmatrix >= 0.18.0.1 && < 0.19
                    , hvx
+                   , deepseq >= 1.4.3.0 && < 1.5
   default-language : Haskell2010
   ghc-options      : -Wall

--- a/hvx.cabal
+++ b/hvx.cabal
@@ -1,5 +1,5 @@
 name               : hvx
-version            : 0.3.0.0
+version            : 0.3.0.1
 synopsis           : Solves convex optimization problems with subgradient methods.
 license-file       : LICENSE
 author             : Chris Copeland and Michael Haggblade

--- a/src/HVX/Internal/Solvers.hs
+++ b/src/HVX/Internal/Solvers.hs
@@ -16,6 +16,7 @@ import Data.List
 import Data.Ord
 import Data.Maybe
 import Numeric.LinearAlgebra
+import Control.DeepSeq (deepseq)
 
 import HVX.Primitives (neg)
 import HVX.Internal.Constraints
@@ -65,7 +66,7 @@ subgradLoop itr objective constraints stepFun maxItr vars =
   if itr >= maxItr || vars == varsNext
     then (vars, evaluate objective vars `atIndex` (0,0))
     else subgradLoop (itr + 1) objective constraints stepFun maxItr varsNext
-      where varsNext = map (updateWithSubgrad objective constraints (stepFun itr) vars) vars
+      where varsNext = deepseq vars $ map (updateWithSubgrad objective constraints (stepFun itr) vars) vars
 
 updateWithSubgrad :: Expr vex mon -> [Constraint] -> Double -> Vars -> (Var, Mat) -> (Var, Mat)
 updateWithSubgrad objective constraints stepSize vars (varname, val) =
@@ -108,7 +109,7 @@ ellipsoidLoop objective constraints tol soids lbound ubound =
   if ubound - lbound < tol || sqrtgpgsum == 0.0
     then (centers, nlbound, nubound)
     else ellipsoidLoop objective constraints tol nsoids nlbound nubound
-      where updates = map (updateEllipsoid objective constraints centers) soids
+      where updates = deepseq soids $ map (updateEllipsoid objective constraints centers) soids
             nsoids = map fst updates
             sqrtgpgsum = sqrt . sum . map snd $ updates
             objval = evaluate objective centers `atIndex` (0,0)


### PR DESCRIPTION
hvx would repeatedly run out of memory after a few minutes. The repeated application of functions via map onto vars / soids created a chain of unforced thunks. This leaked memory. I tried with seq but I couldn't find a good way of using it, so I used deepseq, and that worked great. I've had a problem with a very high iteration count running for an hour already with no memory leak. I haven't actually tried the ellipsoid solver, because I don't have a program written for it; I only tried the subgrad solver, which is why I ran into this bug. However, looking at the code of ellipsoidLoop, it does the exact same thing, so it likely has the same bug. I added deepseq in the same fashion.