### PR TITLE
Compiles and tests run under 9.8.2

### DIFF
--- a/hvx.cabal
+++ b/hvx.cabal
@@ -28,8 +28,8 @@ library
   -- closed type families need ghc>=7.8 which has base==4.7
   build-depends    : base < 5 && >= 4.7
                    , QuickCheck > 2.5
-                   , hmatrix >= 0.18.0.1 && < 0.19
-                   , deepseq >= 1.4.3.0 && < 1.5
+                   , hmatrix >= 0.18.0.1 && < 0.21
+                   , deepseq >= 1.4.3.0 && < 1.6
   hs-source-dirs   : src
   default-language : Haskell2010
   ghc-options      : -Wall
@@ -39,10 +39,23 @@ test-suite haskell-tests
   build-depends    : base < 5
                    , QuickCheck > 2.5
                    , hspec
-                   , hmatrix >= 0.18.0.1 && < 0.19
-                   , deepseq >= 1.4.3.0 && < 1.5
+                   , hmatrix >= 0.18.0.1 && < 0.21
+                   , deepseq >= 1.4.3.0 && < 1.6
   hs-source-dirs   : test, src
   main-is          : Spec.hs
+  other-modules    : HVX
+                   , HVX.BlackBoxTests.HuberTestSpec
+                   , HVX.BlackBoxTests.ManyvarTestSpec
+                   , HVX.Internal.Constraints
+                   , HVX.Internal.DCP
+                   , HVX.Internal.Matrix
+                   , HVX.Internal.Primitives
+                   , HVX.Internal.Solvers
+                   , HVX.Internal.SymbolicSubgrad
+                   , HVX.Internal.TestUtil
+                   , HVX.Internal.Util
+                   , HVX.Primitives
+                   , HVX.SymbolicSubgradSpec
   default-language : Haskell2010
   ghc-options      : -Wall
 
@@ -58,7 +71,8 @@ test-suite shell-tests
                    , directory
                    , process
                    , filepath
-                   , deepseq >= 1.4.3.0 && < 1.5
+                   , hmatrix >= 0.18.0.1 && < 0.21
+                   , deepseq >= 1.4.3.0 && < 1.6
   hs-source-dirs   : test
   main-is          : DcpTests.hs
   default-language : Haskell2010
@@ -69,9 +83,9 @@ executable demo
   main-is          : demo.hs
   build-depends    : base < 5 && >= 4.7
                    , QuickCheck > 2.5
-                   , hmatrix >= 0.18.0.1 && < 0.19
+                   , hmatrix >= 0.18.0.1 && < 0.21
                    , hvx
-                   , deepseq >= 1.4.3.0 && < 1.5
+                   , deepseq >= 1.4.3.0 && < 1.6
   default-language : Haskell2010
   ghc-options      : -Wall
 
@@ -80,8 +94,8 @@ executable subgrad
   main-is          : subgrad.hs
   build-depends    : base < 5 && >= 4.7
                    , QuickCheck > 2.5
-                   , hmatrix >= 0.18.0.1 && < 0.19
+                   , hmatrix >= 0.18.0.1 && < 0.21
                    , hvx
-                   , deepseq >= 1.4.3.0 && < 1.5
+                   , deepseq >= 1.4.3.0 && < 1.6
   default-language : Haskell2010
   ghc-options      : -Wall

--- a/src/HVX/Internal/Primitives.hs
+++ b/src/HVX/Internal/Primitives.hs
@@ -12,6 +12,7 @@ module HVX.Internal.Primitives
   , getProperties
   ) where
 
+import Prelude hiding ((<>))
 import Numeric.LinearAlgebra
 
 import HVX.Internal.Matrix
@@ -94,7 +95,7 @@ getFun Min x = reduceMat minimum x
 getFun (Norm p) x = scalarMat $ lpnorm p x
 getFun (Berhu m) x =
   cmap (\y -> if abs y <= m then abs y else (abs y ** 2 + m ** 2) / (2 * m)) x
-getFun (Huber m) x = 
+getFun (Huber m) x =
   cmap (\y -> if abs y <= m then abs y ** 2 else 2 * m * abs y - m ** 2) x
 getFun (Quadform m) x = tr x <> m <> x
 getFun PowBaseP0 x = konst 1.0 ((rows x), (cols x))

--- a/src/HVX/Internal/Solvers.hs
+++ b/src/HVX/Internal/Solvers.hs
@@ -12,6 +12,8 @@ module HVX.Internal.Solvers
   , ellipsoidLoop
   ) where
 
+import Prelude hiding ((<>))
+
 import Data.List
 import Data.Ord
 import Data.Maybe

--- a/src/HVX/Internal/SymbolicSubgrad.hs
+++ b/src/HVX/Internal/SymbolicSubgrad.hs
@@ -2,6 +2,8 @@
 
 module HVX.Internal.SymbolicSubgrad where
 
+import Prelude hiding ((<>))
+
 import Numeric.LinearAlgebra
 
 import HVX.Internal.Matrix

--- a/src/HVX/Primitives.hs
+++ b/src/HVX/Primitives.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeOperators #-}
 
 module HVX.Primitives
 -- TODO(mh): Currently primitives that should generate implicit constraints are

--- a/test/HVX/SymbolicSubgradSpec.hs
+++ b/test/HVX/SymbolicSubgradSpec.hs
@@ -2,6 +2,8 @@
 
 module HVX.SymbolicSubgradSpec (main, spec) where
 
+import Prelude hiding ((<>))
+
 import Test.Hspec
 import Test.QuickCheck hiding ((><))
 import Numeric.LinearAlgebra


### PR DESCRIPTION
Bumped bounds on hmatrix; had to hide the Prelude ```(<>)``` operator in a few places. And added the ```TypeOperators``` Language pragma in one place in order to suppress a warning (that would eventually become an error).
Now compiles on 9.8.2. 
Tests run and most pass (output pasted below). Not sure what to make of the failures.

Getting the compilation tests to run was finicky. I had to manually add ```hmatrix``` and ```deepseq``` to my local package db (or something?) via ```cabal install --lib hmatrix``` and ```cabal install --lib deepseq``` but YMMV.



```
Preprocessing test suite 'shell-tests' for hvx-0.3.0.1..
Building test suite 'shell-tests' for hvx-0.3.0.1..
Preprocessing test suite 'haskell-tests' for hvx-0.3.0.1..
Building test suite 'haskell-tests' for hvx-0.3.0.1..
Running 1 test suites...
Test suite shell-tests: RUNNING...
Running 1 test suites...
Test suite haskell-tests: RUNNING...

HVX.BlackBoxTests.HuberTest
  Verify that HVX matches CVX for huber/berhu
    Verify that HVX subgrad matches CVX for huber/berhu [✔]
    Verify that HVX ellipsoid matches CVX for huber/berhu [✔]
HVX.BlackBoxTests.ManyvarTest
  Placeholder test
    placeholder description [✔]
HVX.SymbolicSubgrad
  SymbolicSubgrad
    evaluate
      log/exp
        log(exp(x)) = x [✔]
          +++ OK, passed 100 tests.
      log_sum_exp
        log_sum_exp(x) = log(ones'*exp(x)) [✔]
          +++ OK, passed 100 tests.
      max/min
        max(x) = -min(-x) [✔]
          +++ OK, passed 100 tests.
      lpnorm
        lpnorm(x, 1) = sum(abs(x)) [✔]
          +++ OK, passed 100 tests.
        lpnorm(x, 2)^2 = x^T * x [✔]
          +++ OK, passed 100 tests.
      quadform
        quadform(I, x) = x^T x [✔]
          +++ OK, passed 100 tests.
      pow (base variable)
        (x^a)^(1/a) = x (a non integral, a > 1) [✔]
          +++ OK, passed 100 tests.
        (x^a)^(1/a) = x (a even, a > 1) [✔]
          +++ OK, passed 100 tests.
    jacobianWrtVar
      works with respect to a variable that doesn't occur in Expr. [✔]
        +++ OK, passed 100 tests.
      log/exp
        log(exp(x)) - x has zero jacobian [✔]
          +++ OK, passed 100 tests.
      log_sum_exp
        jacobian log_sum_exp(x) = jacobian log(ones'*exp(x)) [✔]
          +++ OK, passed 100 tests.
      max/min
        max(x) + min(-x) has zero jacobian [✔]
          +++ OK, passed 100 tests.
      lpnorm
        jacobian lpnorm(x, 1) = jacobian sum(abs(x)) [✘]
        jacobian lpnorm(0, 2) = 0 [✔]
          +++ OK, passed 100 tests.
      quadform
        jacobian quadform(I, x) = jacobian lpnorm(x, 2)^2 [✔]
          +++ OK, passed 100 tests.
      pow (base variable)
        (x^a)^(1/a) - x has zero jacobian (a non integral, a > 1) [✘]
        (x^a)^(1/a) - x has zero jacobian (a even, a > 1) [✘]

Failures:

  test/HVX/SymbolicSubgradSpec.hs:142:5:
  1) HVX.SymbolicSubgrad.SymbolicSubgrad.jacobianWrtVar.lpnorm jacobian lpnorm(x, 1) = jacobian sum(abs(x))
       Falsified (after 1 test):
         (2><1)
          [ 1.0
          , 0.0 ]

  To rerun use: --match "/HVX.SymbolicSubgrad/SymbolicSubgrad/jacobianWrtVar/lpnorm/jacobian lpnorm(x, 1) = jacobian sum(abs(x))/" --seed 1331411957

  test/HVX/SymbolicSubgradSpec.hs:166:5:
  2) HVX.SymbolicSubgrad.SymbolicSubgrad.jacobianWrtVar, pow (base variable), (x^a)^(1/a) - x has zero jacobian (a non integral, a > 1)
       Falsified (after 1 test):
         ((1><1)
          [ 0.0 ],2.6)

  To rerun use: --match "/HVX.SymbolicSubgrad/SymbolicSubgrad/jacobianWrtVar/pow (base variable)/(x^a)^(1/a) - x has zero jacobian (a non integral, a > 1)/" --seed 1331411957

  test/HVX/SymbolicSubgradSpec.hs:176:5:
  3) HVX.SymbolicSubgrad.SymbolicSubgrad.jacobianWrtVar, pow (base variable), (x^a)^(1/a) - x has zero jacobian (a even, a > 1)
       Falsified (after 1 test):
         ((1><1)
          [ 0.0 ],2.0)

  To rerun use: --match "/HVX.SymbolicSubgrad/SymbolicSubgrad/jacobianWrtVar/pow (base variable)/(x^a)^(1/a) - x has zero jacobian (a even, a > 1)/" --seed 1331411957

Randomized with seed 1331411957

Finished in 1.4214 seconds
20 examples, 3 failures

Test suite haskell-tests: FAIL
Test suite logged to:
/Users/adam/DataScience/hvx/dist-newstyle/build/aarch64-osx/ghc-9.6.3/hvx-0.3.0.1/t/haskell-tests/test/hvx-0.3.0.1-haskell-tests.log
0 of 1 test suites (0 of 1 test cases) passed.
Test suite shell-tests: PASS
Test suite logged to:
/Users/adam/DataScience/hvx/dist-newstyle/build/aarch64-osx/ghc-9.6.3/hvx-0.3.0.1/t/shell-tests/test/hvx-0.3.0.1-shell-tests.log
1 of 1 test suites (1 of 1 test cases) passed.
Error: cabal: Tests failed for test:haskell-tests from hvx-0.3.0.1.
```